### PR TITLE
Made Fast Drimogemon working instantly after beating Drimogemon

### DIFF
--- a/source/DWAP/Addresses.cs
+++ b/source/DWAP/Addresses.cs
@@ -33,7 +33,10 @@ namespace DWAP
         public static ulong LearningChanceStartAddress = 0x00125FA4;
 
         public static ulong MonochromeProfitAddress = 0x0013500C;
-        public static ulong DrimogemonDays = 0x001BE04E;
+        public static ulong HasBeatenDrimogemon = 0x001BE130;
+        public static ulong MeramonTunnel_State = 0x001BE043;
+        public static ulong MeramonTunnel_DrimogemonState = 0x001BE042;
+        public static ulong MeramonTunnel_DiggingState = 0x001BE04F;
 
         public static ulong CardStartAddress = 0x001bdfac;
 

--- a/source/DWAP/App.xaml.cs
+++ b/source/DWAP/App.xaml.cs
@@ -450,7 +450,12 @@ namespace DWAP
             }
             if (_fastDrimogemon)
             {
-                if (Memory.ReadByte(Addresses.DrimogemonDays) < 9) Memory.WriteByte(Addresses.DrimogemonDays, 9);
+                if (Memory.ReadByte(Addresses.HasBeatenDrimogemon) == 1 && Memory.ReadByte(Addresses.MeramonTunnel_DiggingState) == 11)
+                {
+                    Memory.WriteByte(Addresses.MeramonTunnel_DrimogemonState, 2);
+                    Memory.WriteByte(Addresses.MeramonTunnel_State, 10);
+                    Memory.WriteByte(Addresses.MeramonTunnel_DiggingState, 5);
+                }
             }
         }
 


### PR DESCRIPTION
```cs
if (_fastDrimogemon)
{
    if (Memory.ReadByte(Addresses.HasBeatenDrimogemon) == 1 && Memory.ReadByte(Addresses.MeramonTunnel_DiggingState) == 11)
    {
        Memory.WriteByte(Addresses.MeramonTunnel_DrimogemonState, 2); // set Drimogemon to already talked to
        Memory.WriteByte(Addresses.MeramonTunnel_State, 10);          // set tunnel as already dug
        Memory.WriteByte(Addresses.MeramonTunnel_DiggingState, 5);    // set pile as empty
    }
}
```

DiggingState to 11 is pre digging state
Once you talk to the digging Drimogemon it's set to 0 then when the pile is empty it's set to 5.